### PR TITLE
Make gg_check use dict and ignore

### DIFF
--- a/R/check.r
+++ b/R/check.r
@@ -44,7 +44,8 @@ gg_check <- function(gg, dict = hunspell::dictionary("en_US"), ignore = hunspell
 
       words <- stri_extract_all_words(lbl[[lab]])
       words <- unlist(words)
-      words <- purrr::discard(hunspell(words, "text"), ~length(.)==0)
+      words <- purrr::discard(hunspell(words, "text", dict = dict, ignore = ignore),
+                              ~length(.)==0)
 
       if (length(words) > 0) {
         message(sprintf("Possible misspelled words in [%s]: (%s)",


### PR DESCRIPTION
The `dict` and `ignore` parameters weren't being passed to `hunspell`.

Example:
```r
ggplot(mtcars, aes(mpg, wt)) +
    geom_point() +
    labs(x="This is some txt", y="This is more text",
         title="Thisy is a titlle") -> gg

gg_check(gg)
# Possible misspelled words in [title]: (Thisy, titlle)
gg_check(gg, ignore = c('Thisy', 'titlle'))  # no change in output!
# Possible misspelled words in [title]: (Thisy, titlle)
```