### PR TITLE
Fix location of secondary y-axis name when using ggplot2 >= v2.2.0

### DIFF
--- a/R/roboto-condensed.r
+++ b/R/roboto-condensed.r
@@ -143,6 +143,8 @@ theme_ipsum_rc <- function(
                                                family=axis_title_family, face=axis_title_face))
   ret <- ret + theme(axis.title.y=element_text(hjust=yj, size=axis_title_size,
                                                family=axis_title_family, face=axis_title_face))
+  ret <- ret + theme(axis.title.y.right=element_text(hjust=yj, size=axis_title_size, angle=90,
+                                                     family=axis_title_family, face=axis_title_face))
   ret <- ret + theme(strip.text=element_text(hjust=0, size=strip_text_size,
                                              face=strip_text_face, family=strip_text_family))
   ret <- ret + theme(panel.spacing.x=grid::unit(2, "lines"))

--- a/R/theme-ipsum.r
+++ b/R/theme-ipsum.r
@@ -148,6 +148,8 @@ theme_ipsum <- function(base_family="Arial Narrow", base_size = 11.5,
                                                family=axis_title_family, face=axis_title_face))
   ret <- ret + theme(axis.title.y=element_text(hjust=yj, size=axis_title_size,
                                                family=axis_title_family, face=axis_title_face))
+  ret <- ret + theme(axis.title.y.right=element_text(hjust=yj, size=axis_title_size, angle=90,
+                                               family=axis_title_family, face=axis_title_face))
   ret <- ret + theme(strip.text=element_text(hjust=0, size=strip_text_size,
                                              face=strip_text_face, family=strip_text_family))
   ret <- ret + theme(panel.spacing.x=grid::unit(2, "lines"))


### PR DESCRIPTION
When using the new secondary axis in ggplot2 >= v2.2.0 the axis name ends up at the bottom (near zero).

Reproducible example below.

``` r
library(tidyverse)

ggplot(mtcars, aes(mpg, wt)) +
  geom_point() +
  labs(x="Fuel effiiency (mpg)", y="Weight (tons)",
       title="Seminal ggplot2 scatterplot example",
       subtitle="A plot that is only useful for demonstration purposes",
       caption="Brought to you by the letter 'g'") + 
  theme_ipsum() +
  scale_y_continuous(sec.axis = sec_axis(~.*5,name = "y2 axis name"))
```

This pull request adds in code to adjust the location of the secondary axis name to what seems like (in my opinion) a more sensible place.

Happy to hear thoughts on whether it was an intentional design choice, or just unexpected side-effect of the upgrade to ggplot v2.2.0.