### PR TITLE
Fix typo in theme_ipsum_rc.Rd

### DIFF
--- a/man/theme_ipsum_rc.Rd
+++ b/man/theme_ipsum_rc.Rd
@@ -38,7 +38,7 @@ theme_modern_rc(base_family = "Roboto Condensed", base_size = 11.5,
 \arguments{
 \item{base_family, base_size}{base font family and size}
 
-\item{plot_title_family, plot_title_face, plot_title_size, plot_title_margin}{plot tilte family, face, size and margi}
+\item{plot_title_family, plot_title_face, plot_title_size, plot_title_margin}{plot tilte family, face, size and margin}
 
 \item{subtitle_family, subtitle_face, subtitle_size}{plot subtitle family, face and size}
 


### PR DESCRIPTION
fixed typo in description of the arguments "plot_title_family, plot_title_face, plot_title_size, plot_title_margin"