### PR TITLE
Fixed missing end quote mark.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Utilities:
 ### Installation
 
 ``` r
-install.packages("hrbrthemes) # NOTE: CRAN version is 0.8.0
+install.packages("hrbrthemes") # NOTE: CRAN version is 0.8.0
 # or
 install.packages("hrbrthemes", repos = c("https://cinc.rud.is", "https://cloud.r-project.org/"))
 # or


### PR DESCRIPTION
Please note that this fixes the missing quote mark from the output of the `hrbrpkghelpr::install_block()` function in Readme.md, not the function itself as used in the .Rmd (which must be located elsewhere?)

This is intended as a stop-gap measure, until the function itself is fixed.

PS: Thanks for the amazing package!